### PR TITLE
ci(bot): move api credentials to secrets

### DIFF
--- a/.github/bot/bot.py
+++ b/.github/bot/bot.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Constants
-TG_API_ID = 30232030
-TG_API_HASH = "9272d8aa731deacaa93a7906c7f9b44c"
 TG_MSG_TEMPLATE_CI = """
 New push to Github
 <pre>
@@ -60,6 +58,8 @@ class Settings(BaseSettings):
     chat_id: int
     run_no: int
     run_id: int
+    api_id: int
+    api_hash: str
     bot_ci_session: str | None = None
     github_repository: str
     github_token: str
@@ -314,8 +314,8 @@ async def post(msg: str, files: list[str], parse_mode: str):
         Awaitable,
         TelegramClient(
             StringSession(cast(str, settings.bot_ci_session)),
-            TG_API_ID,
-            TG_API_HASH,
+            settings.api_id,
+            settings.api_hash,
         ).start(bot_token=settings.bot_token),
     )
     async with bot:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           CHAT_ID: ${{ secrets.CHAT_ID }}
+          TG_API_ID: ${{ secrets.TG_API_ID }}
+          TG_API_HASH: ${{ secrets.TG_API_HASH }}
           BOT_CI_SESSION: ${{ secrets.BOT_CI_SESSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSIST_TOKEN: ${{ secrets.PERSIST_TOKEN }}
@@ -96,7 +98,7 @@ jobs:
           RUN_NO: ${{ github.run_number }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ] || [ -z "${BOT_CI_SESSION:-}" ]; then
+          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ] || [ -z "${TG_API_ID:-}" ] || [ -z "${TG_API_HASH:-}" ] || [ -z "${BOT_CI_SESSION:-}" ]; then
             exit 0
           fi
           pip3 install -r .github/bot/requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
         env:
           BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
           CHAT_ID: ${{ secrets.CHAT_ID }}
+          TG_API_ID: ${{ secrets.TG_API_ID }}
+          TG_API_HASH: ${{ secrets.TG_API_HASH }}
           BOT_CI_SESSION: ${{ secrets.BOT_CI_SESSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSIST_TOKEN: ${{ secrets.PERSIST_TOKEN }}
@@ -90,7 +92,7 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           IS_RELEASE: true
         run: |
-          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ] || [ -z "${BOT_CI_SESSION:-}" ]; then
+          if [ -z "${BOT_TOKEN:-}" ] || [ -z "${CHAT_ID:-}" ] || [ -z "${TG_API_ID:-}" ] || [ -z "${TG_API_HASH:-}" ] || [ -z "${BOT_CI_SESSION:-}" ]; then
             exit 0
           fi
           pip3 install -r .github/bot/requirements.txt


### PR DESCRIPTION
- Remove hardcoded TG_API_ID and TG_API_HASH from bot.py
- Add api_id and api_hash to Settings class, sourced from env vars
- Update ci.yml and release.yml to pass TG_API_ID/TG_API_HASH secrets